### PR TITLE
fixing code formatting issue

### DIFF
--- a/MathTools/src/MathUtils.cc
+++ b/MathTools/src/MathUtils.cc
@@ -79,7 +79,7 @@ void MathUtils::CalcRatio(Double_t n1, Double_t n2, Double_t &r, Double_t &rlow,
 //--------------------------------------------------------------------------------------------------
 Double_t MathUtils::DeltaPhi(Double_t phi1, Double_t phi2)
 {
- // Compute DeltaPhi between two given phi angles. Results is in [-pi,pi] where phi1-phi2 is used
+  // Compute DeltaPhi between two given phi angles. Results is in [-pi,pi] where phi1-phi2 is used
   // meaning we point from phi1 to phi2, using the sign as mathematically positive == counter clock.
 
   Double_t dphi = phi1-phi2;


### PR DESCRIPTION
Hi Christoph,

   MathTools/src/MathUtils.cc produces a weird character when downloaded 
(L82). It seems this is a formatting issue, but unfortunately it makes the code
uncompilable. Here is the fix.
Leonardo
