### PR TITLE
Not using environment variable HOSTNAME in DomainName()

### DIFF
--- a/Utils/interface/Utils.h
+++ b/Utils/interface/Utils.h
@@ -21,7 +21,7 @@ namespace mithep
     public:
       static TString     GetEnv(const char* name);    // get environment variable with proper check
       static TString     GetEnv(TString name);        // "
-      static TString     DomainName();                // get domain name (uses HOSTNAME)
+      static TString     DomainName();                // get domain name
       static TString     GetCatalogDir(const char* name); // get the catalog directory
       static TString     GetJsonFile(const char* name);   // get the json file
       template<class C>
@@ -45,11 +45,11 @@ inline TString mithep::Utils::GetEnv(const char* name)
 }
 inline TString mithep::Utils::DomainName()
 {
-  if (! gSystem->Getenv("HOSTNAME")) {
-    printf(" Environment variable: HOSTNAME not defined. EXIT!\n");
+  if (!gSystem->HostName()) {
+    printf(" Host name not available. EXIT!\n");
     return TString("");
   } 
-  TString domainName = gSystem->Getenv("HOSTNAME");
+  TString domainName = gSystem->HostName();
   domainName.Replace(0,domainName.First('.')+1,0,0);
   return domainName;
 }


### PR DESCRIPTION
In the Utils::DomainName() function the environment variable $HOSTNAME is used. This variable is however a special feature of bash, and is not guaranteed to be set automatically. In MitAna/bin/submit.sh we explicitly tell condor to set this variable, but TUnixSystem also comes with a function HostName() [1] which is more reliable (uses system calls).

[1] https://root.cern.ch/root/html604/src/TUnixSystem.cxx.html#UZglwB