### PR TITLE
making tmp directory in genDict

### DIFF
--- a/bin/genDict.sh
+++ b/bin/genDict.sh
@@ -94,6 +94,7 @@ fi
 echo " $PACKAGES"
 
 TMPDIR=$CMSSW_BASE/tmp/$SCRAM_ARCH
+mkdir -p $TMPDIR
 
 cd $CMSSW_BASE/src
 


### PR DESCRIPTION
Very minor fix for a slightly annoying feature, which was that the genDict fails after scram b clean because the tmp directory is removed.